### PR TITLE
Update NaverCustomAuthenticator.java

### DIFF
--- a/componenets/org.wso2.carbon.identity.application.authenticator.naver/src/main/java/org.wso2.carbon.identity.application.authenticator.naver/NaverCustomAuthenticator.java
+++ b/componenets/org.wso2.carbon.identity.application.authenticator.naver/src/main/java/org.wso2.carbon.identity.application.authenticator.naver/NaverCustomAuthenticator.java
@@ -190,9 +190,11 @@ public class NaverCustomAuthenticator extends Oauth2GenericAuthenticator {
                 Iterator keys = userInfoJson.keys();
                 while (keys.hasNext()) {
                     String key = (String) keys.next();
-                    if (userInfoJson.get(key) instanceof JSONObject) {
-                        claims.put(ClaimMapping.build(key, key, null, false),
-                                (String) userInfoJson.get(key));
+                    Object value = userInfoJson.get(key);
+                    if (value instanceof JSONObject) {
+                        claims.put(ClaimMapping.build(key, key, null, false), value.toString());
+                    } else if (value instanceof String) {
+                        claims.put(ClaimMapping.build(key, key, null, false), (String) value);
                     }
                 }
                 String subjectFromClaims = FrameworkUtils


### PR DESCRIPTION
value instanceof JSONObject  is false
https://github.com/wso2-extensions/identity-outbound-auth-naver/issues/16
wso2 iam 7.1.0 


Purpose
This feature/fix is driven by the need to enable Naver login functionality within WSO2 Identity Server. Currently, there isn't a pre-built, readily available connector for Naver, requiring manual integration and configuration steps.
Resolves: wso2-extensions/identity-outbound-auth-naver/issues/16

Goals
This feature aims to introduce a dedicated Naver Outbound Authentication Connector for WSO2 Identity Server. This will simplify the process of integrating Naver as an identity provider, allowing users to authenticate via their Naver accounts.

Approach
We are implementing this solution by developing a new WSO2 Identity Server connector specifically for Naver's OAuth 2.0 based authentication. This involves:

Developing the Naver connector JAR: This JAR will contain the necessary logic to interact with Naver's OAuth 2.0 endpoints for authentication and user profile retrieval.

Integrating with WSO2 Identity Server: The connector will be designed to seamlessly plug into the existing WSO2 Identity Server's outbound authentication framework.

Providing configuration options: The connector will expose configuration parameters (e.g., Client ID, Client Secret, Callback URL) within the WSO2 Identity Server administrative UI, making it easy for administrators to set up.

(Once UI changes are available, an animated GIF or screenshot demonstrating the new Naver Identity Provider configuration in the WSO2 Identity Server UI will be included here.)

User stories
As an administrator, I want to easily configure Naver as an external identity provider in WSO2 Identity Server so that my users can log in using their Naver accounts.

As a user, I want to be able to log in to applications integrated with WSO2 Identity Server using my existing Naver account for a seamless authentication experience.

Release note
Introduced a new WSO2 Identity Server connector for Naver outbound authentication, enabling seamless integration with Naver as an identity provider.